### PR TITLE
Move to f42 with digest

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:41
+FROM registry.fedoraproject.org/fedora:42@sha256:4e2ac5a754dc80babb40100857d27a028f7cbb077bf0a7e4cc66c2533c37c6a2
 
 # https://github.com/containers/buildah/issues/3666#issuecomment-1351992335
 VOLUME /var/lib/containers


### PR DESCRIPTION
Digest should ensure that renovate will notice updated fedora images.