### PR TITLE
Add redhat-rpm-config package into the Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,7 +6,7 @@ VOLUME /var/lib/containers
 ADD rpmdiff.patch /rpmdiff.patch
 
 RUN \
-    dnf -y install mock koji dist-git-client patch python3-specfile && \
+    dnf -y install mock koji dist-git-client patch python3-specfile redhat-rpm-config && \
     patch /usr/lib/python3.13/site-packages/koji/rpmdiff.py < /rpmdiff.patch && \
     dnf remove -y patch && \
     dnf -y clean all && \


### PR DESCRIPTION
To avoid issues like:

    specfile.exceptions.RPMException: invalid syntax in lua scriptlet: [string "%postun"]:10: unexpected symbol near '%'

when building the gcc package, which is caused by missing `lua-srpm-macros` package.

Because there are more `*-srpm-macros` packages out there, I'm adding the `redhat-rpm-config` that requires them, instead of adding each of them individually.