### PR TITLE
Fix ExcludeArch handling

### DIFF
--- a/python_scripts/select_architectures.py
+++ b/python_scripts/select_architectures.py
@@ -35,8 +35,8 @@ def get_arches(name, tags):
     unknown = " ".join([x for x in values if x.startswith("%")])
     if unknown:
         print(f"Unknown macros in {name_map[name]}: {unknown}")
-        return []
-    return values
+        return set()
+    return set(values)
 
 
 def get_macros(specfile_path):
@@ -152,10 +152,10 @@ def _main():
 
     build_architectures = allowed_architectures
     if arches['exclusivearch']:
-        build_architectures &= set(arches["exclusivearch"])
+        build_architectures &= arches["exclusivearch"]
     if arches['excludearch']:
         build_architectures -= arches["excludearch"]
-    if arches['buildarch'] == ['noarch']:
+    if arches['buildarch'] == set(['noarch']):
         selected_architectures = [random.choice(list(build_architectures))]
     else:
         # this case we catch other buildArch values instead of noarch, for example buildArch: x86_64.

--- a/tests/specfiles/dummy-pkg-exclude-exclusive-arch.spec
+++ b/tests/specfiles/dummy-pkg-exclude-exclusive-arch.spec
@@ -1,0 +1,40 @@
+Name:		dummy-pkg-exclude-exclusive-arch
+Version:	1.0
+Release:	1%{?dist}
+Summary:	A dummy package
+
+License:	GPLv3+
+URL:		http://example.com/
+ExcludeArch:	s390x
+ExclusiveArch:	%java_arches
+
+Source0:	https://raw.githubusercontent.com/praiskup/quick-package/master/README.xz
+
+
+%description
+Description for the %name package that is used for various testing tasks.
+
+
+%prep
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_pkgdocdir}
+xz -d %{SOURCE0} --stdout > $RPM_BUILD_ROOT/%{_pkgdocdir}/README
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%dir %{_pkgdocdir}
+%doc %{_pkgdocdir}/README
+
+%changelog
+* Thu Jun 05 2014 Pavel Raiskup <praiskup@redhat.com> - 0-1
+- does nothing!

--- a/tests/specfiles/dummy-pkg-noarch.spec
+++ b/tests/specfiles/dummy-pkg-noarch.spec
@@ -1,0 +1,41 @@
+Name:		dummy-pkg-exclude-exclusive-arch
+Version:	1.0
+Release:	1%{?dist}
+Summary:	A dummy package
+
+License:	GPLv3+
+URL:		http://example.com/
+
+BuildArch:	noarch
+ExclusiveArch:	x86_64 aarch64
+
+Source0:	https://raw.githubusercontent.com/praiskup/quick-package/master/README.xz
+
+
+%description
+Description for the %name package that is used for various testing tasks.
+
+
+%prep
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_pkgdocdir}
+xz -d %{SOURCE0} --stdout > $RPM_BUILD_ROOT/%{_pkgdocdir}/README
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%dir %{_pkgdocdir}
+%doc %{_pkgdocdir}/README
+
+%changelog
+* Thu Jun 05 2014 Pavel Raiskup <praiskup@redhat.com> - 0-1
+- does nothing!

--- a/tests/test_select_architectures.py
+++ b/tests/test_select_architectures.py
@@ -22,20 +22,24 @@ def _testdir(specfile):
     return workdir
 
 
+def _run_selected_architectures(specfile, additional_args=None):
+    testdir = _testdir(specfile)
+    results = os.path.join(testdir, "results.json")
+    sys.argv = ["this", "--workdir", testdir,
+                "--results-file", results] + SELECTED_ARCHES
+    if additional_args:
+        sys.argv += additional_args
+    select_architectures()
+    with open(results, "r", encoding="utf-8") as rfd:
+        return json.load(rfd)
+
+
 def test_basic_noarch():
     """
     Norpm + exclusive_arch use-case.
     """
-
-    testdir = _testdir("gdb-exploitable.spec")
-    results = os.path.join(testdir, "results.json")
-    sys.argv = ["this", "--hermetic", "--workdir", testdir,
-                "--results-file", results] + SELECTED_ARCHES
-
-    select_architectures()
-    with open(results, "r", encoding="utf-8") as rfd:
-        results = json.load(rfd)
-
+    results = _run_selected_architectures("gdb-exploitable.spec",
+                                          ["--hermetic"])
     # This should build only on x86_64
     assert results == {
         "deps-x86_64": "linux/amd64",
@@ -55,15 +59,8 @@ def test_basic_multiarch_hermetic():
     """
     Without buildArch + exclusive_arch use-case.
     """
-
-    testdir = _testdir("dpdk.spec")
-    results = os.path.join(testdir, "results.json")
-    sys.argv = ["this", "--hermetic", "--workdir", testdir,
-                "--results-file", results] + SELECTED_ARCHES
-
-    select_architectures()
-    with open(results, "r", encoding="utf-8") as rfd:
-        results = json.load(rfd)
+    results = _run_selected_architectures("dpdk.spec",
+                                          ["--hermetic"])
 
     # This should build on x86_64, aarch64 and ppc64le
     assert results == {
@@ -84,16 +81,7 @@ def test_basic_multiarch_not_hermetic():
     """
     Without buildArch + exclusive_arch use-case and without hermetic option.
     """
-
-    testdir = _testdir("dpdk.spec")
-    results = os.path.join(testdir, "results.json")
-    sys.argv = ["this", "--workdir", testdir,
-                "--results-file", results] + SELECTED_ARCHES
-
-    select_architectures()
-    with open(results, "r", encoding="utf-8") as rfd:
-        results = json.load(rfd)
-
+    results = _run_selected_architectures("dpdk.spec")
     # This should build on x86_64, aarch64 and ppc64le
     assert results == {
         "deps-x86_64": "localhost",
@@ -107,3 +95,57 @@ def test_basic_multiarch_not_hermetic():
         "build-s390x": "localhost",
         "build-ppc64le": "linux/ppc64le"
     }
+
+
+def test_exclude_arch():
+    """
+    Test package with both ExclusiveArch and ExcludeArch statements.
+    """
+    results = _run_selected_architectures("dummy-pkg-exclude-exclusive-arch.spec")
+    # exclusivearch covers all architectures, but excludearch
+    # drops s390x.
+    assert results == {
+        "deps-x86_64": "localhost",
+        "deps-i686": "localhost",
+        "deps-aarch64": "localhost",
+        "deps-s390x": "localhost",
+        "deps-ppc64le": "localhost",
+        "build-x86_64": "linux/amd64",
+        "build-i686": "localhost",
+        "build-aarch64": "linux/arm64",
+        "build-s390x": "localhost",
+        "build-ppc64le": "linux/ppc64le"
+    }
+
+
+def test_noarch_and_exclusive_arch():
+    """
+    Test package with both ExclusiveArch and ExcludeArch statements.
+    """
+    results = _run_selected_architectures("dummy-pkg-noarch.spec",
+                                          ["--hermetic"])
+    # ExclusiveArch covers all available_architectures, but excludearch
+    # filters-out s390x and ppc64le.  Noarch picks x86_64 or aarch64 randomly.
+    assert results in [{
+        "deps-x86_64": "localhost",
+        "deps-aarch64": "linux/arm64",
+        "deps-i686": "localhost",
+        "deps-s390x": "localhost",
+        "deps-ppc64le": "localhost",
+        "build-x86_64": "localhost",
+        "build-aarch64": "linux/arm64",
+        "build-i686": "localhost",
+        "build-s390x": "localhost",
+        "build-ppc64le": "localhost"
+    }, {
+        "deps-x86_64": "linux/amd64",
+        "deps-aarch64": "localhost",
+        "deps-i686": "localhost",
+        "deps-s390x": "localhost",
+        "deps-ppc64le": "localhost",
+        "build-x86_64": "linux/amd64",
+        "build-aarch64": "localhost",
+        "build-i686": "localhost",
+        "build-s390x": "localhost",
+        "build-ppc64le": "localhost"
+    }]


### PR DESCRIPTION
We couldn't do set() operations with list in arches["excludearch"]. Newly we make sure that all the fields are sets.

Add coverage for noarch packages, and ExcludeArch packages.