### PR TITLE
use absolute path for buildroot lockfile location

### DIFF
--- a/python_scripts/gather_rpms.py
+++ b/python_scripts/gather_rpms.py
@@ -175,7 +175,8 @@ def handle_archdir(arch, pipeline_id):
         broot_arch_rpms[arch] = {
             "filelist": all_rpms,
             # we don't symlink buildroot_lock.json, just note its location
-            "lockfile": lockfile_path}
+            "lockfile": os.path.abspath(lockfile_path)
+        }
         logging.debug("(S)RPMs built in %s Buildroot:\n%s", arch, pprint.pformat(rpms, indent=2))
         logging.debug("Buildroot lockfile: %s", broot_arch_rpms[arch]["lockfile"])
         prepare_koji_broot(arch, pipeline_id, lockfile_path=lockfile_path)

--- a/tests/test_gather_rpms.py
+++ b/tests/test_gather_rpms.py
@@ -429,6 +429,12 @@ class TestHandleArchdirIntegration(unittest.TestCase):
         self.assertIn("bar-2.0-1.el9.x86_64.rpm", gather_rpms.broot_arch_rpms["x86_64"]["filelist"])
         self.assertIn("test-1.0-1.el9.src.rpm", gather_rpms.broot_arch_rpms["x86_64"]["filelist"])
 
+        # Verify lockfile path is absolute and correct
+        lockfile = gather_rpms.broot_arch_rpms["x86_64"]["lockfile"]
+        self.assertTrue(os.path.isabs(lockfile), f"lockfile path should be absolute: {lockfile}")
+        expected_lockfile = os.path.join(self.temp_dir, "x86_64", "results", "buildroot_lock.json")
+        self.assertEqual(lockfile, expected_lockfile)
+
     @patch('gather_rpms.pick_ancestors')
     @patch('gather_rpms.symlink')
     @patch('gather_rpms.pick_sbom')


### PR DESCRIPTION
The path was the relpath to `$workdir/results` when executing gather_rpms.py. But when executing `merge_sboms.py` the current dir is `$workdir/results/oras-staging`. Using an abspath is an easy fix for this problem. 

Generated-by: Claude Code