### PR TITLE
More SBOM fixes in merge_sboms.py

### DIFF
--- a/python_scripts/merge_sboms.py
+++ b/python_scripts/merge_sboms.py
@@ -21,18 +21,21 @@ from sbom_utils import to_spdx_license, get_generic_purl, get_rpm_purl
 
 
 DEFAULT_CONFIG_PATH = "/etc/rpmbuild_sbom/config.json"
-DEFAULT_SBOM_CREATOR = "Tool: Konflux"
+DEFAULT_SBOM_CREATORS = ["Tool: Konflux", "Organization: Fedora"]
+DEFAULT_ANNOTATOR = "Tool: Konflux"
 DEFAULT_DOCUMENT_NAMESPACE = "https://fedoraproject.org/{nvr}.spdx.json"
 DEFAULT_SUPPLIER = "Organization: Fedora"
+DEFAULT_PURL_RPM_NAMESPACE = "fedora"
 
 SBOM_CREATED_TIME = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 # Global config instance, initialized via init_config()
 CONFIG = {
-    "sbom_creator": DEFAULT_SBOM_CREATOR,
+    "sbom_creators": list(DEFAULT_SBOM_CREATORS),
+    "annotator": DEFAULT_ANNOTATOR,
     "document_namespace": DEFAULT_DOCUMENT_NAMESPACE,
     "supplier": DEFAULT_SUPPLIER,
-    "purl_rpm_namespace": "fedora",
+    "purl_rpm_namespace": DEFAULT_PURL_RPM_NAMESPACE,
 }
 
 
@@ -119,9 +122,7 @@ def create_base_sbom(rpm_dir):
         "SPDXID": "SPDXRef-DOCUMENT",
         "creationInfo": {
             "created": SBOM_CREATED_TIME,
-            "creators": [
-                CONFIG["sbom_creator"]
-            ],
+            "creators": CONFIG["sbom_creators"],
         },
         "name": nvr,
         "documentNamespace": CONFIG["document_namespace"].format(nvr=nvr),
@@ -560,7 +561,7 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
             if sigmd5:
                 pkg_dict["annotations"].append({
                     "annotationType": "OTHER",
-                    "annotator": CONFIG["sbom_creator"],
+                    "annotator": CONFIG["annotator"],
                     "annotationDate": SBOM_CREATED_TIME,
                     "comment": f"sigmd5: {sigmd5}",
                 })
@@ -569,7 +570,7 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
             if sha256header:
                 pkg_dict["annotations"].append({
                     "annotationType": "OTHER",
-                    "annotator": CONFIG["sbom_creator"],
+                    "annotator": CONFIG["annotator"],
                     "annotationDate": SBOM_CREATED_TIME,
                     "comment": f"sha256header: {sha256header}",
                 })

--- a/python_scripts/merge_sboms.py
+++ b/python_scripts/merge_sboms.py
@@ -20,8 +20,39 @@ from common_utils import calc_checksum
 from sbom_utils import to_spdx_license, get_generic_purl, get_rpm_purl
 
 
-SBOM_CREATOR = "Tool: Konflux"
+DEFAULT_CONFIG_PATH = "/etc/rpmbuild_sbom/config.json"
+DEFAULT_SBOM_CREATOR = "Tool: Konflux"
+DEFAULT_DOCUMENT_NAMESPACE = "https://fedoraproject.org/{nvr}.spdx.json"
+DEFAULT_SUPPLIER = "Organization: Fedora"
+
 SBOM_CREATED_TIME = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+# Global config instance, initialized via init_config()
+CONFIG = {
+    "sbom_creator": DEFAULT_SBOM_CREATOR,
+    "document_namespace": DEFAULT_DOCUMENT_NAMESPACE,
+    "supplier": DEFAULT_SUPPLIER,
+    "purl_rpm_namespace": "fedora",
+}
+
+
+def init_config(config_path=None):
+    """Load SBOM generation config from JSON file into global CONFIG.
+
+    :param config_path: Path to config JSON file (default: DEFAULT_CONFIG_PATH)
+    :type config_path: str or None
+    """
+    path = config_path or DEFAULT_CONFIG_PATH
+    if os.path.exists(path):
+        try:
+            with open(path, encoding="utf-8") as f:
+                user_config = json.load(f)
+            CONFIG.update({k: v for k, v in user_config.items() if k in CONFIG})
+            logging.info("Loaded config from %s", path)
+        except (json.JSONDecodeError, OSError) as e:
+            logging.warning("Failed to load config from %s: %s, using defaults", path, e)
+    elif config_path:
+        logging.warning("Config file not found: %s, using defaults", config_path)
 
 
 def get_params():
@@ -44,6 +75,11 @@ def get_params():
         '--syft-sbom-dir',
         default='.',
         help="Directory containing syft-generated SBOM files for SRPM and binary RPMs (default: current directory)"
+    )
+    parser.add_argument(
+        '--config',
+        default=None,
+        help=f"Path to SBOM config JSON file (default: {DEFAULT_CONFIG_PATH})"
     )
     args = parser.parse_args()
     return args
@@ -84,11 +120,11 @@ def create_base_sbom(rpm_dir):
         "creationInfo": {
             "created": SBOM_CREATED_TIME,
             "creators": [
-                SBOM_CREATOR
+                CONFIG["sbom_creator"]
             ],
         },
         "name": nvr,
-        "documentNamespace": f"https://www.redhat.com/{nvr}.spdx.json",
+        "documentNamespace": CONFIG["document_namespace"].format(nvr=nvr),
         "packages": [],
         "files": [],
         "relationships": [
@@ -138,7 +174,7 @@ def create_base_sbom(rpm_dir):
             "SPDXID": spdxid,
             "name": rpminfo['name'],
             "versionInfo": f"{rpminfo['version']}-{rpminfo['release']}",
-            "supplier": "Organization: Red Hat",
+            "supplier": CONFIG["supplier"],
             "downloadLocation": "NOASSERTION",
             "packageFileName": rpm,
             "licenseDeclared": spdx_license,
@@ -151,7 +187,8 @@ def create_base_sbom(rpm_dir):
                         version=rpminfo['version'],
                         release=rpminfo['release'],
                         arch=rpminfo['arch'],
-                        epoch=rpminfo.get('epoch')
+                        epoch=rpminfo.get('epoch'),
+                        namespace=CONFIG["purl_rpm_namespace"],
                     ),
                 }
             ],
@@ -514,7 +551,7 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
                 "downloadLocation": rpm.get("url", "NOASSERTION"),
                 "licenseDeclared": to_spdx_license(rpm.get("license")),
                 "filesAnalyzed": False,
-                "supplier": "Organization: Red Hat",
+                "supplier": CONFIG["supplier"],
                 "annotations": []
             }
 
@@ -523,7 +560,7 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
             if sigmd5:
                 pkg_dict["annotations"].append({
                     "annotationType": "OTHER",
-                    "annotator": SBOM_CREATOR,
+                    "annotator": CONFIG["sbom_creator"],
                     "annotationDate": SBOM_CREATED_TIME,
                     "comment": f"sigmd5: {sigmd5}",
                 })
@@ -532,7 +569,7 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
             if sha256header:
                 pkg_dict["annotations"].append({
                     "annotationType": "OTHER",
-                    "annotator": SBOM_CREATOR,
+                    "annotator": CONFIG["sbom_creator"],
                     "annotationDate": SBOM_CREATED_TIME,
                     "comment": f"sha256header: {sha256header}",
                 })
@@ -546,7 +583,8 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
                     version=rpm["version"],
                     release=rpm["release"],
                     arch=rpm["arch"],
-                    epoch=rpm.get("epoch")
+                    epoch=rpm.get("epoch"),
+                    namespace=CONFIG["purl_rpm_namespace"],
                 )
             }]
 
@@ -646,6 +684,7 @@ def merge_sboms(
 
 def _main():
     args = get_params()
+    init_config(args.config)
 
     # Generate base SBOM from RPM directory
     root_sbom = create_base_sbom(args.rpm_dir)

--- a/python_scripts/merge_sboms.py
+++ b/python_scripts/merge_sboms.py
@@ -88,6 +88,30 @@ def get_params():
     return args
 
 
+def _add_rpm_annotations(pkg_dict, sigmd5, sha256header):
+    """Add sigmd5 and sha256header annotations to a package dict.
+
+    :param pkg_dict: SPDX package dictionary to add annotations to
+    :type pkg_dict: dict
+    :param sigmd5: RPM sigmd5 value (may be None)
+    :param sha256header: RPM sha256header value (may be None)
+    """
+    if sigmd5:
+        pkg_dict.setdefault("annotations", []).append({
+            "annotationType": "OTHER",
+            "annotator": CONFIG["annotator"],
+            "annotationDate": SBOM_CREATED_TIME,
+            "comment": f"sigmd5: {sigmd5}",
+        })
+    if sha256header:
+        pkg_dict.setdefault("annotations", []).append({
+            "annotationType": "OTHER",
+            "annotator": CONFIG["annotator"],
+            "annotationDate": SBOM_CREATED_TIME,
+            "comment": f"sha256header: {sha256header}",
+        })
+
+
 def create_base_sbom(rpm_dir):
     """Generate base SBOM from RPM directory.
 
@@ -200,6 +224,10 @@ def create_base_sbom(rpm_dir):
                 }
             ],
         })
+
+        _add_rpm_annotations(
+            sbom['packages'][-1], rpminfo.get('sigmd5'), rpminfo.get('sha256header')
+        )
 
         # All binary RPMs are generated from SRPM
         if rpminfo['arch'] != "src":
@@ -553,27 +581,9 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
                 "licenseDeclared": to_spdx_license(rpm.get("license")),
                 "filesAnalyzed": False,
                 "supplier": CONFIG["supplier"],
-                "annotations": []
             }
 
-            # Add checksum if sigmd5 as an annotation
-            sigmd5 = rpm.get("sigmd5")
-            if sigmd5:
-                pkg_dict["annotations"].append({
-                    "annotationType": "OTHER",
-                    "annotator": CONFIG["annotator"],
-                    "annotationDate": SBOM_CREATED_TIME,
-                    "comment": f"sigmd5: {sigmd5}",
-                })
-            # Add sha256header if sha256header as an annotation (mock doesn't provide it yet)
-            sha256header = rpm.get("sha256header")
-            if sha256header:
-                pkg_dict["annotations"].append({
-                    "annotationType": "OTHER",
-                    "annotator": CONFIG["annotator"],
-                    "annotationDate": SBOM_CREATED_TIME,
-                    "comment": f"sha256header: {sha256header}",
-                })
+            _add_rpm_annotations(pkg_dict, rpm.get("sigmd5"), rpm.get("sha256header"))
 
             # Add RPM purl as external reference
             pkg_dict["externalRefs"] = [{

--- a/python_scripts/sbom_utils.py
+++ b/python_scripts/sbom_utils.py
@@ -24,7 +24,7 @@ def get_generic_purl(name, version=None, url=None, checksum=None, alg=None):
     return purl
 
 
-def get_rpm_purl(name, version, release, arch, epoch=None):
+def get_rpm_purl(name, version, release, arch, *, epoch=None, namespace="fedora"):
     """Generate Package URL (purl) for an RPM package.
 
     :param name: Package name
@@ -37,15 +37,17 @@ def get_rpm_purl(name, version, release, arch, epoch=None):
     :type arch: str
     :param epoch: Package epoch (optional)
     :type epoch: str or None
+    :param namespace: RPM purl namespace (e.g. "fedora", "redhat")
+    :type namespace: str
     :returns: RPM purl string
     :rtype: str
     """
-    # Format: pkg:rpm/redhat/name@version-release?arch=...
+    # Format: pkg:rpm/namespace/name@version-release?arch=...
     version_str = f"{version}-{release}"
     if epoch:
         version_str = f"{epoch}:{version_str}"
 
-    purl = f"pkg:rpm/redhat/{name}@{version_str}?arch={arch}"
+    purl = f"pkg:rpm/{namespace}/{name}@{version_str}?arch={arch}"
     return purl
 
 

--- a/tests/test_merge_sboms.py
+++ b/tests/test_merge_sboms.py
@@ -21,11 +21,99 @@ from merge_sboms import (
     attach_syft_sboms,
     _find_rpm_packages,
     _rename_doc_root_id,
+    _add_rpm_annotations,
     DEFAULT_SBOM_CREATORS,
     DEFAULT_ANNOTATOR,
     DEFAULT_DOCUMENT_NAMESPACE,
     DEFAULT_SUPPLIER,
+    SBOM_CREATED_TIME,
 )
+
+
+class TestAddRpmAnnotations(unittest.TestCase):
+    """Unit tests for _add_rpm_annotations function."""
+
+    def test_add_sigmd5_only(self):
+        """Test adding sigmd5 annotation only."""
+        pkg_dict = {"SPDXID": "SPDXRef-test"}
+        _add_rpm_annotations(pkg_dict, "abc123def456", None)
+
+        self.assertIn("annotations", pkg_dict)
+        self.assertEqual(len(pkg_dict["annotations"]), 1)
+        self.assertEqual(pkg_dict["annotations"][0]["annotationType"], "OTHER")
+        self.assertEqual(pkg_dict["annotations"][0]["annotator"], CONFIG["annotator"])
+        self.assertEqual(pkg_dict["annotations"][0]["annotationDate"], SBOM_CREATED_TIME)
+        self.assertEqual(pkg_dict["annotations"][0]["comment"], "sigmd5: abc123def456")
+
+    def test_add_sha256header_only(self):
+        """Test adding sha256header annotation only."""
+        pkg_dict = {"SPDXID": "SPDXRef-test"}
+        _add_rpm_annotations(pkg_dict, None, "fedcba987654")
+
+        self.assertIn("annotations", pkg_dict)
+        self.assertEqual(len(pkg_dict["annotations"]), 1)
+        self.assertEqual(pkg_dict["annotations"][0]["annotationType"], "OTHER")
+        self.assertEqual(pkg_dict["annotations"][0]["annotator"], CONFIG["annotator"])
+        self.assertEqual(pkg_dict["annotations"][0]["annotationDate"], SBOM_CREATED_TIME)
+        self.assertEqual(pkg_dict["annotations"][0]["comment"], "sha256header: fedcba987654")
+
+    def test_add_both_annotations(self):
+        """Test adding both sigmd5 and sha256header annotations."""
+        pkg_dict = {"SPDXID": "SPDXRef-test"}
+        _add_rpm_annotations(pkg_dict, "abc123", "xyz789")
+
+        self.assertIn("annotations", pkg_dict)
+        self.assertEqual(len(pkg_dict["annotations"]), 2)
+
+        # Check first annotation is sigmd5
+        self.assertEqual(pkg_dict["annotations"][0]["annotationType"], "OTHER")
+        self.assertEqual(pkg_dict["annotations"][0]["annotator"], CONFIG["annotator"])
+        self.assertEqual(pkg_dict["annotations"][0]["annotationDate"], SBOM_CREATED_TIME)
+        self.assertEqual(pkg_dict["annotations"][0]["comment"], "sigmd5: abc123")
+
+        # Check second annotation is sha256header
+        self.assertEqual(pkg_dict["annotations"][1]["annotationType"], "OTHER")
+        self.assertEqual(pkg_dict["annotations"][1]["annotator"], CONFIG["annotator"])
+        self.assertEqual(pkg_dict["annotations"][1]["annotationDate"], SBOM_CREATED_TIME)
+        self.assertEqual(pkg_dict["annotations"][1]["comment"], "sha256header: xyz789")
+
+    def test_add_neither_annotation(self):
+        """Test with neither sigmd5 nor sha256header."""
+        pkg_dict = {"SPDXID": "SPDXRef-test"}
+        _add_rpm_annotations(pkg_dict, None, None)
+
+        # Should not create annotations key if neither value provided
+        self.assertNotIn("annotations", pkg_dict)
+
+    def test_existing_annotations_preserved(self):
+        """Test that existing annotations are preserved."""
+        pkg_dict = {
+            "SPDXID": "SPDXRef-test",
+            "annotations": [
+                {
+                    "annotationType": "REVIEW",
+                    "annotator": "Person: Reviewer",
+                    "annotationDate": "2024-01-01T00:00:00Z",
+                    "comment": "Existing annotation"
+                }
+            ]
+        }
+        _add_rpm_annotations(pkg_dict, "abc123", "xyz789")
+
+        self.assertEqual(len(pkg_dict["annotations"]), 3)
+        # First annotation is the existing one
+        self.assertEqual(pkg_dict["annotations"][0]["comment"], "Existing annotation")
+        # New annotations added after
+        self.assertEqual(pkg_dict["annotations"][1]["comment"], "sigmd5: abc123")
+        self.assertEqual(pkg_dict["annotations"][2]["comment"], "sha256header: xyz789")
+
+    def test_empty_string_not_added(self):
+        """Test that empty strings are not added as annotations."""
+        pkg_dict = {"SPDXID": "SPDXRef-test"}
+        _add_rpm_annotations(pkg_dict, "", "")
+
+        # Empty strings are falsy, so no annotations should be added
+        self.assertNotIn("annotations", pkg_dict)
 
 
 class TestAttachSources(unittest.TestCase):
@@ -657,6 +745,81 @@ class TestCreateBaseSbom(unittest.TestCase):
                 "[CRITICAL] Binary RPM foo-1.0-1.el9.noarch.rpm has sourcerpm header bar-2.0-1.el9.src.rpm"
                 " that does not match expected SRPM foo-1.0-1.el9.src.rpm",
             )
+
+    @patch('merge_sboms.to_spdx_license', return_value="MIT")
+    @patch('merge_sboms.calc_checksum', return_value="abc123")
+    @patch('merge_sboms.koji')
+    def test_base_sbom_adds_rpm_annotations(self, mock_koji, _mock_checksum, _mock_license):
+        """Test create_base_sbom adds RPM annotations for sigmd5 and sha256header."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ["test-1.0-1.el9.src.rpm", "test-1.0-1.el9.x86_64.rpm"]:
+                with open(os.path.join(tmpdir, name), 'w', encoding='utf-8'):
+                    pass
+
+            # SRPM with both sigmd5 and sha256header
+            # Binary RPM with sigmd5 only
+            mock_koji.get_header_fields.side_effect = [
+                {"name": "test", "version": "1.0", "release": "1.el9",
+                 "arch": "x86_64", "description": "test", "license": "MIT",
+                 "sigmd5": "srpm-sigmd5", "sha256header": "srpm-sha256",
+                 "sourcepackage": 1, "sourcerpm": None},
+                {"name": "test", "version": "1.0", "release": "1.el9",
+                 "arch": "x86_64", "description": "test", "license": "MIT",
+                 "sigmd5": "rpm-sigmd5", "sha256header": None,
+                 "sourcepackage": None, "sourcerpm": "test-1.0-1.el9.src.rpm"},
+            ]
+
+            sbom = create_base_sbom(tmpdir)
+
+        # Check SRPM package has both annotations
+        srpm_pkg = sbom['packages'][0]
+        self.assertEqual(srpm_pkg['SPDXID'], "SPDXRef-SRPM")
+        self.assertIn("annotations", srpm_pkg)
+        self.assertEqual(len(srpm_pkg['annotations']), 2)
+
+        # Verify sigmd5 annotation
+        sigmd5_annot = [a for a in srpm_pkg['annotations'] if 'sigmd5' in a['comment']][0]
+        self.assertEqual(sigmd5_annot['annotationType'], 'OTHER')
+        self.assertEqual(sigmd5_annot['annotator'], CONFIG['annotator'])
+        self.assertEqual(sigmd5_annot['comment'], 'sigmd5: srpm-sigmd5')
+
+        # Verify sha256header annotation
+        sha256_annot = [a for a in srpm_pkg['annotations'] if 'sha256header' in a['comment']][0]
+        self.assertEqual(sha256_annot['annotationType'], 'OTHER')
+        self.assertEqual(sha256_annot['annotator'], CONFIG['annotator'])
+        self.assertEqual(sha256_annot['comment'], 'sha256header: srpm-sha256')
+
+        # Check binary RPM package has sigmd5 annotation only
+        bin_pkg = sbom['packages'][1]
+        self.assertEqual(bin_pkg['SPDXID'], "SPDXRef-x86_64-test")
+        self.assertIn("annotations", bin_pkg)
+        self.assertEqual(len(bin_pkg['annotations']), 1)
+        self.assertEqual(bin_pkg['annotations'][0]['comment'], 'sigmd5: rpm-sigmd5')
+
+    @patch('merge_sboms.to_spdx_license', return_value="MIT")
+    @patch('merge_sboms.calc_checksum', return_value="abc123")
+    @patch('merge_sboms.koji')
+    def test_base_sbom_no_annotations_when_none(self, mock_koji, _mock_checksum, _mock_license):
+        """Test create_base_sbom does not add annotations when headers are None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ["test-1.0-1.el9.src.rpm"]:
+                with open(os.path.join(tmpdir, name), 'w', encoding='utf-8'):
+                    pass
+
+            # SRPM without sigmd5 or sha256header
+            mock_koji.get_header_fields.side_effect = [
+                {"name": "test", "version": "1.0", "release": "1.el9",
+                 "arch": "x86_64", "description": "test", "license": "MIT",
+                 "sigmd5": None, "sha256header": None,
+                 "sourcepackage": 1, "sourcerpm": None},
+            ]
+
+            sbom = create_base_sbom(tmpdir)
+
+        # Check SRPM package has no annotations
+        srpm_pkg = sbom['packages'][0]
+        self.assertEqual(srpm_pkg['SPDXID'], "SPDXRef-SRPM")
+        self.assertNotIn("annotations", srpm_pkg)
 
 
 class TestMergeSboms(unittest.TestCase):

--- a/tests/test_merge_sboms.py
+++ b/tests/test_merge_sboms.py
@@ -21,7 +21,8 @@ from merge_sboms import (
     attach_syft_sboms,
     _find_rpm_packages,
     _rename_doc_root_id,
-    DEFAULT_SBOM_CREATOR,
+    DEFAULT_SBOM_CREATORS,
+    DEFAULT_ANNOTATOR,
     DEFAULT_DOCUMENT_NAMESPACE,
     DEFAULT_SUPPLIER,
 )
@@ -1077,7 +1078,8 @@ class TestInitConfig(unittest.TestCase):
     def _reset_config(self):
         """Reset CONFIG to defaults."""
         CONFIG.update({
-            "sbom_creator": DEFAULT_SBOM_CREATOR,
+            "sbom_creators": list(DEFAULT_SBOM_CREATORS),
+            "annotator": DEFAULT_ANNOTATOR,
             "document_namespace": DEFAULT_DOCUMENT_NAMESPACE,
             "supplier": DEFAULT_SUPPLIER,
             "purl_rpm_namespace": "fedora",
@@ -1092,7 +1094,7 @@ class TestInitConfig(unittest.TestCase):
     def test_loads_valid_config(self):
         """Test loading a valid config file overrides defaults."""
         config_data = {
-            "sbom_creator": "Tool: MyTool",
+            "sbom_creators": ["Tool: MyTool", "Tool: Other"],
             "supplier": "Organization: ACME",
         }
 
@@ -1102,7 +1104,7 @@ class TestInitConfig(unittest.TestCase):
 
         try:
             init_config(config_path)
-            self.assertEqual(CONFIG["sbom_creator"], "Tool: MyTool")
+            self.assertEqual(CONFIG["sbom_creators"], ["Tool: MyTool", "Tool: Other"])
             self.assertEqual(CONFIG["supplier"], "Organization: ACME")
             # Unchanged keys keep defaults
             self.assertEqual(CONFIG["document_namespace"], DEFAULT_DOCUMENT_NAMESPACE)
@@ -1113,7 +1115,7 @@ class TestInitConfig(unittest.TestCase):
     def test_ignores_unknown_keys(self):
         """Test that unknown keys in config file are ignored."""
         config_data = {
-            "sbom_creator": "Tool: Custom",
+            "sbom_creators": ["Tool: Custom"],
             "unknown_key": "should be ignored",
         }
 
@@ -1123,7 +1125,7 @@ class TestInitConfig(unittest.TestCase):
 
         try:
             init_config(config_path)
-            self.assertEqual(CONFIG["sbom_creator"], "Tool: Custom")
+            self.assertEqual(CONFIG["sbom_creators"], ["Tool: Custom"])
             self.assertNotIn("unknown_key", CONFIG)
         finally:
             os.unlink(config_path)
@@ -1131,13 +1133,13 @@ class TestInitConfig(unittest.TestCase):
     def test_missing_explicit_path_keeps_defaults(self):
         """Test that a nonexistent explicit path logs warning and keeps defaults."""
         init_config("/nonexistent/path/config.json")
-        self.assertEqual(CONFIG["sbom_creator"], DEFAULT_SBOM_CREATOR)
+        self.assertEqual(CONFIG["sbom_creators"], list(DEFAULT_SBOM_CREATORS))
         self.assertEqual(CONFIG["supplier"], DEFAULT_SUPPLIER)
 
     def test_missing_default_path_keeps_defaults(self):
         """Test that missing default config path keeps defaults silently."""
         init_config(None)
-        self.assertEqual(CONFIG["sbom_creator"], DEFAULT_SBOM_CREATOR)
+        self.assertEqual(CONFIG["sbom_creators"], list(DEFAULT_SBOM_CREATORS))
         self.assertEqual(CONFIG["supplier"], DEFAULT_SUPPLIER)
 
     def test_invalid_json_keeps_defaults(self):
@@ -1148,7 +1150,7 @@ class TestInitConfig(unittest.TestCase):
 
         try:
             init_config(config_path)
-            self.assertEqual(CONFIG["sbom_creator"], DEFAULT_SBOM_CREATOR)
+            self.assertEqual(CONFIG["sbom_creators"], list(DEFAULT_SBOM_CREATORS))
             self.assertEqual(CONFIG["supplier"], DEFAULT_SUPPLIER)
         finally:
             os.unlink(config_path)
@@ -1156,7 +1158,8 @@ class TestInitConfig(unittest.TestCase):
     def test_all_keys_configurable(self):
         """Test that all CONFIG keys can be overridden."""
         config_data = {
-            "sbom_creator": "Tool: X",
+            "sbom_creators": ["Tool: X", "Tool: Y"],
+            "annotator": "Tool: X",
             "document_namespace": "https://example.com/{nvr}.spdx.json",
             "supplier": "Organization: X",
             "purl_rpm_namespace": "centos",
@@ -1168,7 +1171,8 @@ class TestInitConfig(unittest.TestCase):
 
         try:
             init_config(config_path)
-            self.assertEqual(CONFIG["sbom_creator"], "Tool: X")
+            self.assertEqual(CONFIG["sbom_creators"], ["Tool: X", "Tool: Y"])
+            self.assertEqual(CONFIG["annotator"], "Tool: X")
             self.assertEqual(CONFIG["document_namespace"], "https://example.com/{nvr}.spdx.json")
             self.assertEqual(CONFIG["supplier"], "Organization: X")
             self.assertEqual(CONFIG["purl_rpm_namespace"], "centos")

--- a/tests/test_merge_sboms.py
+++ b/tests/test_merge_sboms.py
@@ -13,12 +13,17 @@ from unittest.mock import patch
 
 from merge_sboms import (
     _main as merge_sboms,
+    CONFIG,
+    init_config,
     create_base_sbom,
     attach_sources,
     attach_buildroot_packages,
     attach_syft_sboms,
     _find_rpm_packages,
     _rename_doc_root_id,
+    DEFAULT_SBOM_CREATOR,
+    DEFAULT_DOCUMENT_NAMESPACE,
+    DEFAULT_SUPPLIER,
 )
 
 
@@ -308,7 +313,7 @@ class TestAttachBuildrootPackages(unittest.TestCase):
             self.assertEqual(gcc_pkg['name'], 'gcc')
             self.assertEqual(gcc_pkg['versionInfo'], '11.3.1-4.el9')
             self.assertEqual(gcc_pkg['licenseDeclared'], 'GPL-3.0-or-later')
-            self.assertEqual(gcc_pkg['supplier'], 'Organization: Red Hat')
+            self.assertEqual(gcc_pkg['supplier'], 'Organization: Fedora')
 
             # Check annotations (sigmd5 is stored as annotation)
             self.assertEqual(len(gcc_pkg['annotations']), 1)
@@ -317,7 +322,7 @@ class TestAttachBuildrootPackages(unittest.TestCase):
 
             # Check purl
             self.assertEqual(len(gcc_pkg['externalRefs']), 1)
-            self.assertIn('pkg:rpm/redhat/gcc@11.3.1-4.el9?arch=x86_64',
+            self.assertIn('pkg:rpm/fedora/gcc@11.3.1-4.el9?arch=x86_64',
                           gcc_pkg['externalRefs'][0]['referenceLocator'])
 
             # Check relationships - should have 2 CONTAINS relationships
@@ -1064,6 +1069,111 @@ class TestAttachSyftSboms(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             attach_syft_sboms(sbom_root, None)
         self.assertIn("syft_sbom_dir parameter is required", str(cm.exception))
+
+
+class TestInitConfig(unittest.TestCase):
+    """Unit tests for init_config function."""
+
+    def _reset_config(self):
+        """Reset CONFIG to defaults."""
+        CONFIG.update({
+            "sbom_creator": DEFAULT_SBOM_CREATOR,
+            "document_namespace": DEFAULT_DOCUMENT_NAMESPACE,
+            "supplier": DEFAULT_SUPPLIER,
+            "purl_rpm_namespace": "fedora",
+        })
+
+    def setUp(self):
+        self._reset_config()
+
+    def tearDown(self):
+        self._reset_config()
+
+    def test_loads_valid_config(self):
+        """Test loading a valid config file overrides defaults."""
+        config_data = {
+            "sbom_creator": "Tool: MyTool",
+            "supplier": "Organization: ACME",
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+            json.dump(config_data, f)
+            config_path = f.name
+
+        try:
+            init_config(config_path)
+            self.assertEqual(CONFIG["sbom_creator"], "Tool: MyTool")
+            self.assertEqual(CONFIG["supplier"], "Organization: ACME")
+            # Unchanged keys keep defaults
+            self.assertEqual(CONFIG["document_namespace"], DEFAULT_DOCUMENT_NAMESPACE)
+            self.assertEqual(CONFIG["purl_rpm_namespace"], "fedora")
+        finally:
+            os.unlink(config_path)
+
+    def test_ignores_unknown_keys(self):
+        """Test that unknown keys in config file are ignored."""
+        config_data = {
+            "sbom_creator": "Tool: Custom",
+            "unknown_key": "should be ignored",
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+            json.dump(config_data, f)
+            config_path = f.name
+
+        try:
+            init_config(config_path)
+            self.assertEqual(CONFIG["sbom_creator"], "Tool: Custom")
+            self.assertNotIn("unknown_key", CONFIG)
+        finally:
+            os.unlink(config_path)
+
+    def test_missing_explicit_path_keeps_defaults(self):
+        """Test that a nonexistent explicit path logs warning and keeps defaults."""
+        init_config("/nonexistent/path/config.json")
+        self.assertEqual(CONFIG["sbom_creator"], DEFAULT_SBOM_CREATOR)
+        self.assertEqual(CONFIG["supplier"], DEFAULT_SUPPLIER)
+
+    def test_missing_default_path_keeps_defaults(self):
+        """Test that missing default config path keeps defaults silently."""
+        init_config(None)
+        self.assertEqual(CONFIG["sbom_creator"], DEFAULT_SBOM_CREATOR)
+        self.assertEqual(CONFIG["supplier"], DEFAULT_SUPPLIER)
+
+    def test_invalid_json_keeps_defaults(self):
+        """Test that invalid JSON in config file keeps defaults."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+            f.write("not valid json{{{")
+            config_path = f.name
+
+        try:
+            init_config(config_path)
+            self.assertEqual(CONFIG["sbom_creator"], DEFAULT_SBOM_CREATOR)
+            self.assertEqual(CONFIG["supplier"], DEFAULT_SUPPLIER)
+        finally:
+            os.unlink(config_path)
+
+    def test_all_keys_configurable(self):
+        """Test that all CONFIG keys can be overridden."""
+        config_data = {
+            "sbom_creator": "Tool: X",
+            "document_namespace": "https://example.com/{nvr}.spdx.json",
+            "supplier": "Organization: X",
+            "purl_rpm_namespace": "centos",
+        }
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+            json.dump(config_data, f)
+            config_path = f.name
+
+        try:
+            init_config(config_path)
+            self.assertEqual(CONFIG["sbom_creator"], "Tool: X")
+            self.assertEqual(CONFIG["document_namespace"], "https://example.com/{nvr}.spdx.json")
+            self.assertEqual(CONFIG["supplier"], "Organization: X")
+            self.assertEqual(CONFIG["purl_rpm_namespace"], "centos")
+        finally:
+            os.unlink(config_path)
 
 
 if __name__ == "__main__":

--- a/tests/test_sbom_utils.py
+++ b/tests/test_sbom_utils.py
@@ -94,7 +94,7 @@ class TestGetRpmPurl(unittest.TestCase):
             release="4.el9",
             arch="x86_64"
         )
-        self.assertEqual(purl, "pkg:rpm/redhat/gcc@11.3.1-4.el9?arch=x86_64")
+        self.assertEqual(purl, "pkg:rpm/fedora/gcc@11.3.1-4.el9?arch=x86_64")
 
     def test_rpm_purl_with_epoch(self):
         """Test RPM purl with epoch."""
@@ -105,7 +105,7 @@ class TestGetRpmPurl(unittest.TestCase):
             arch="aarch64",
             epoch="2"
         )
-        self.assertEqual(purl, "pkg:rpm/redhat/systemd@2:252-13.el9?arch=aarch64")
+        self.assertEqual(purl, "pkg:rpm/fedora/systemd@2:252-13.el9?arch=aarch64")
 
     def test_rpm_purl_noarch(self):
         """Test RPM purl with noarch architecture."""
@@ -115,7 +115,7 @@ class TestGetRpmPurl(unittest.TestCase):
             release="7.el9",
             arch="noarch"
         )
-        self.assertEqual(purl, "pkg:rpm/redhat/python3-pip@21.2.3-7.el9?arch=noarch")
+        self.assertEqual(purl, "pkg:rpm/fedora/python3-pip@21.2.3-7.el9?arch=noarch")
 
 
 class TestToSpdxLicense(unittest.TestCase):


### PR DESCRIPTION
* now we can specify some constants for sbom in a json file by  --config, default: `/etc/rpmbuild_sbom/config.json`
* S(RPM)s now have annotations (contains sigmd5 and sha256header of rpms) as the same as buildroot packages
* the default rpm prul namespace, supplier, creators are fedora now