### PR TITLE
Make fedora-infra repo use $relesever

### DIFF
--- a/repofiles/fedora-infra.repo
+++ b/repofiles/fedora-infra.repo
@@ -1,6 +1,6 @@
-[fedora-43-infra]
-baseurl = https://kojipkgs.fedoraproject.org/repos-dist/f43-infra/latest/$basearch/
+[fedora-infra]
+baseurl = https://kojipkgs.fedoraproject.org/repos-dist/f$releasever-infra/latest/$basearch/
 enabled = 1
 gpgcheck = 1
 gpgkey=https://infrastructure.fedoraproject.org/repo/infra/RPM-GPG-KEY-INFRA-TAGS
-name = Fedora 43 infra repo
+name = Fedora infrastructure repo


### PR DESCRIPTION
This will automatically move us to Infra 44 repo once we move to the (soon to be stable) F44 base image.