### PR TITLE
fix: handle RPM #/ URL fragment renames in Source tag resolution

### DIFF
--- a/python_scripts/gen_ancestors_from_src.py
+++ b/python_scripts/gen_ancestors_from_src.py
@@ -230,7 +230,11 @@ def list_spec_sources(specfile, srcdir="."):
         # If it's a local path, use basename
         if loc.startswith(UPSTREAM_URL_SCHEMES):
             url = loc
-            sfn = os.path.basename(url.split("#")[0])  # Remove fragment, get basename
+            if "#/" in loc:
+                # RPM convention: #/filename renames the downloaded file
+                sfn = loc.split("#/", 1)[1]
+            else:
+                sfn = os.path.basename(url.split("#")[0])
         else:
             url = None
             sfn = os.path.basename(loc)

--- a/tests/test_gen_ancestors_from_src.py
+++ b/tests/test_gen_ancestors_from_src.py
@@ -326,18 +326,37 @@ class TestListSpecSources(unittest.TestCase):
     @patch("gen_ancestors_from_src.parse_spec_source_tags")
     @patch("gen_ancestors_from_src.calc_checksum", return_value="abc123")
     def test_url_with_fragment(self, _mock_checksum, mock_parse):
-        """Test URL with fragment (#) is handled correctly."""
+        """Test URL with #/ fragment uses the renamed filename."""
         mock_parse.return_value = {
             "0": "https://example.com/pkg-2.0.tar.gz#/renamed.tar.gz"
         }
         with tempfile.TemporaryDirectory() as tmpdir:
-            source_path = os.path.join(tmpdir, "pkg-2.0.tar.gz")
+            source_path = os.path.join(tmpdir, "renamed.tar.gz")
             with open(source_path, 'w', encoding="utf-8") as f:
                 f.write("dummy")
 
             sources = list_spec_sources("fake.spec", tmpdir)
 
-        self.assertEqual(sources[0]["filename"], "pkg-2.0.tar.gz")
+        self.assertEqual(sources[0]["filename"], "renamed.tar.gz")
+        self.assertEqual(sources[0]["url"], "https://example.com/pkg-2.0.tar.gz#/renamed.tar.gz")
+
+    @patch("gen_ancestors_from_src.parse_spec_source_tags")
+    @patch("gen_ancestors_from_src.calc_checksum", return_value="abc123")
+    def test_url_with_fragment_github_archive(self, _mock_checksum, mock_parse):
+        """Test GitHub archive URL with #/ fragment rename (real-world pattern)."""
+        mock_parse.return_value = {
+            "0": "https://github.com/capstone-engine/capstone/archive/5.0.7.tar.gz#/capstone-5.0.7.tar.gz"
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_path = os.path.join(tmpdir, "capstone-5.0.7.tar.gz")
+            with open(source_path, 'w', encoding="utf-8") as f:
+                f.write("dummy")
+
+            sources = list_spec_sources("fake.spec", tmpdir)
+
+        self.assertEqual(sources[0]["filename"], "capstone-5.0.7.tar.gz")
+        self.assertEqual(sources[0]["name"], "capstone")
+        self.assertEqual(sources[0]["version"], "5.0.7")
 
     @patch("gen_ancestors_from_src.parse_spec_source_tags")
     @patch("gen_ancestors_from_src.calc_checksum", return_value="fakechecksum")


### PR DESCRIPTION
## Summary
- RPM specs use `#/` URL fragments to rename downloaded source files (e.g. `Source0: https://.../archive/5.0.7.tar.gz#/capstone-5.0.7.tar.gz`)
- `list_spec_sources()` in `gen_ancestors_from_src.py` was stripping the fragment and using the raw URL basename, causing `FileNotFoundError` when the file in srcdir was saved under the fragment-renamed name
- Fix: when `#/` is present in the URL, use the fragment value as the filename instead of the URL basename

See failure logs [here](https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/hummingbird-tenant/applications/rpms-main/pipelineruns/capstone-main-on-pull-request-q6f7k/logs) generated from [this MR](https://gitlab.com/redhat/hummingbird/rpms/-/merge_requests/2082).

From the [Fedora packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/SourceURL/#_troublesome_urls):

```
When upstream has URLs for the download that do not end with the tarball name rpm will be
unable to parse the tarball out of the source URL. One workaround for many cases is to
construct a URL where the tarball is listed in a "URL fragment":

Source: https://example.com/foo/1.0/download.cgi#/%{name}-%{version}.tar.gz
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)