### PR TITLE
fix(gather_rpms): skip logs for arch dirs with no RPMs

### DIFF
--- a/python_scripts/gather_rpms.py
+++ b/python_scripts/gather_rpms.py
@@ -168,10 +168,8 @@ def handle_archdir(arch, pipeline_id):
 
     # buildroots
     if all_rpms:
+        os.makedirs(os.path.join(STAGING_DIR, arch), exist_ok=True)
         for filename in arch_logs:
-            log_dir = os.path.join(STAGING_DIR, arch)
-            if not os.path.exists(log_dir):
-                os.mkdir(log_dir)
             logs.append((arch, filename))
             symlink(filename, arch, prepend_arch=True)
         lockfile_path = os.path.join(arch, 'results', 'buildroot_lock.json')

--- a/python_scripts/gather_rpms.py
+++ b/python_scripts/gather_rpms.py
@@ -138,6 +138,7 @@ def handle_archdir(arch, pipeline_id):
     logging.info("Handling archdir %s", arch)
     logging.debug("Contents of archdir %s are %s", arch, os.listdir(arch))
     all_rpms = []
+    arch_logs = []
     for filename in os.listdir(arch):
         logging.debug("Handling filename %s", filename)
         if filename.endswith('.noarch.rpm'):
@@ -161,16 +162,18 @@ def handle_archdir(arch, pipeline_id):
             symlink(filename, arch)
             pick_sbom(rpm_filename=filename, arch=arch)
         elif filename.endswith('.log'):
-            log_dir = os.path.join(STAGING_DIR, arch)
-            if not os.path.exists(log_dir):
-                os.mkdir(log_dir)
-            logs.append((arch, filename))
-            symlink(filename, arch, prepend_arch=True)
+            arch_logs.append(filename)
         else:
             continue
 
     # buildroots
     if all_rpms:
+        for filename in arch_logs:
+            log_dir = os.path.join(STAGING_DIR, arch)
+            if not os.path.exists(log_dir):
+                os.mkdir(log_dir)
+            logs.append((arch, filename))
+            symlink(filename, arch, prepend_arch=True)
         lockfile_path = os.path.join(arch, 'results', 'buildroot_lock.json')
         broot_arch_rpms[arch] = {
             "filelist": all_rpms,

--- a/tests/test_gather_rpms.py
+++ b/tests/test_gather_rpms.py
@@ -458,6 +458,50 @@ class TestHandleArchdirIntegration(unittest.TestCase):
         # Verify broot_arch_rpms was not populated
         self.assertNotIn("aarch64", gather_rpms.broot_arch_rpms)
 
+    @patch('gather_rpms.pick_ancestors')
+    @patch('gather_rpms.symlink')
+    @patch('gather_rpms.pick_sbom')
+    @patch('gather_rpms.prepare_koji_broot')
+    def test_handle_archdir_logs_only_no_rpms(
+            self, mock_prepare_koji_broot, _mock_pick_sbom,
+            mock_symlink, _mock_pick_ancestors):
+        """Test handle_archdir skips logs when arch has no RPMs.
+
+        This happens with noarch packages built on multiple architectures:
+        the first arch claims all noarch RPMs, leaving subsequent arch
+        directories with only log files and no RPMs.
+        """
+        pipeline_id = "test-pipeline-789"
+
+        # Simulate the first arch claiming the noarch RPMs
+        first_arch = "aarch64"
+        os.makedirs(os.path.join(self.temp_dir, first_arch), exist_ok=True)
+        for f in ["foo-1.0-1.fc42.noarch.rpm", "foo-1.0-1.fc42.src.rpm", "build.log"]:
+            with open(os.path.join(self.temp_dir, first_arch, f), 'w', encoding='utf-8'):
+                pass
+        handle_archdir(first_arch, pipeline_id)
+        self.assertEqual(len(gather_rpms.logs), 1)
+        mock_symlink.reset_mock()
+
+        # Second arch has the same noarch RPMs (already claimed) plus logs
+        second_arch = "x86_64"
+        os.makedirs(os.path.join(self.temp_dir, second_arch), exist_ok=True)
+        for f in ["foo-1.0-1.fc42.noarch.rpm", "foo-1.0-1.fc42.src.rpm", "build.log"]:
+            with open(os.path.join(self.temp_dir, second_arch, f), 'w', encoding='utf-8'):
+                pass
+        handle_archdir(second_arch, pipeline_id)
+
+        # x86_64 should not have a buildroot since all its RPMs were duplicates
+        self.assertNotIn("x86_64", gather_rpms.broot_arch_rpms)
+        mock_prepare_koji_broot.assert_called_once()
+
+        # Logs from x86_64 should NOT be collected since no RPMs were new
+        self.assertEqual(len(gather_rpms.logs), 1)
+        self.assertEqual(gather_rpms.logs[0], ("aarch64", "build.log"))
+
+        # No symlinks should have been created for x86_64
+        mock_symlink.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- When a noarch package is built on multiple architectures, the first arch claims all noarch RPMs via deduplication. Subsequent arch directories contain only duplicate RPMs and log files, so no buildroot entry is created for them.
- However, logs were still collected for these empty arches, causing a `KeyError` crash in `create_md_file` when it tried to look up the missing buildroot to assign a `buildroot_id` to the log entry.
- Fix: defer log collection until after RPM processing, and only collect logs for arches that contributed at least one new RPM.

## Test plan
- [x] Existing tests pass (14/14)
- [x] Added `test_handle_archdir_logs_only_no_rpms` test that simulates the noarch multi-arch scenario: first arch claims all noarch RPMs, second arch has only duplicates and logs — verifies no buildroot, logs, or symlinks are created for the second arch

🤖 Generated with [Claude Code](https://claude.com/claude-code)