### PR TITLE
SBOM - epoch is a separate attribute

### DIFF
--- a/python_scripts/merge_sboms.py
+++ b/python_scripts/merge_sboms.py
@@ -196,8 +196,8 @@ def create_base_sbom(rpm_dir):
         spdx_license = to_spdx_license(rpminfo['license'])
 
         version_info = f"{rpminfo['version']}-{rpminfo['release']}"
-        if rpminfo.get("epoch"):
-            version_info = f"{rpminfo['version']:verion_info}"
+        if rpminfo.get("epoch") and str(rpminfo['epoch'] != "0"):
+            version_info = f"{rpminfo['version']}:{version_info}"
 
         sbom['packages'].append({
             "SPDXID": spdxid,
@@ -573,7 +573,7 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
 
             # Build version string (version-release with optional epoch prefix)
             version_info = f"{rpm['version']}-{rpm['release']}"
-            if rpm.get('epoch'):
+            if rpm.get("epoch") and str(rpm["epoch"] != "0"):
                 version_info = f"{rpm['epoch']}:{version_info}"
 
             # Create buildroot package dictionary

--- a/python_scripts/merge_sboms.py
+++ b/python_scripts/merge_sboms.py
@@ -569,14 +569,15 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
 
             # Build version string (version-release with optional epoch prefix)
             version = f"{rpm['version']}-{rpm['release']}"
+            epoch_version = version
             if rpm.get('epoch'):
-                version = f"{rpm['epoch']}:{version}"
+                epoch_version = f"{rpm['epoch']}:{version}"
 
             # Create buildroot package dictionary
             pkg_dict = {
                 "SPDXID": spdx_id,
                 "name": rpm["name"],
-                "versionInfo": version,
+                "versionInfo": epoch_version,
                 "downloadLocation": rpm.get("url", "NOASSERTION"),
                 "licenseDeclared": to_spdx_license(rpm.get("license")),
                 "filesAnalyzed": False,

--- a/python_scripts/merge_sboms.py
+++ b/python_scripts/merge_sboms.py
@@ -195,10 +195,14 @@ def create_base_sbom(rpm_dir):
         # Get license and convert to SPDX format
         spdx_license = to_spdx_license(rpminfo['license'])
 
+        version_info = f"{rpminfo['version']}-{rpminfo['release']}"
+        if rpminfo.get("epoch"):
+            version_info = f"{rpminfo['version']:verion_info}"
+
         sbom['packages'].append({
             "SPDXID": spdxid,
             "name": rpminfo['name'],
-            "versionInfo": f"{rpminfo['version']}-{rpminfo['release']}",
+            "versionInfo": version_info,
             "supplier": CONFIG["supplier"],
             "downloadLocation": "NOASSERTION",
             "packageFileName": rpm,
@@ -568,16 +572,15 @@ def attach_buildroot_packages(sbom_root, broot_arch_list_file, srpm_name):  # py
             spdx_id = f"SPDXRef-Buildroot-Package-{rpm['name']}-{target_arch}".replace('_', '-')
 
             # Build version string (version-release with optional epoch prefix)
-            version = f"{rpm['version']}-{rpm['release']}"
-            epoch_version = version
+            version_info = f"{rpm['version']}-{rpm['release']}"
             if rpm.get('epoch'):
-                epoch_version = f"{rpm['epoch']}:{version}"
+                version_info = f"{rpm['epoch']}:{version_info}"
 
             # Create buildroot package dictionary
             pkg_dict = {
                 "SPDXID": spdx_id,
                 "name": rpm["name"],
-                "versionInfo": epoch_version,
+                "versionInfo": version_info,
                 "downloadLocation": rpm.get("url", "NOASSERTION"),
                 "licenseDeclared": to_spdx_license(rpm.get("license")),
                 "filesAnalyzed": False,

--- a/python_scripts/sbom_utils.py
+++ b/python_scripts/sbom_utils.py
@@ -44,10 +44,10 @@ def get_rpm_purl(name, version, release, arch, *, epoch=None, namespace="fedora"
     """
     # Format: pkg:rpm/namespace/name@version-release?arch=...
     version_str = f"{version}-{release}"
-    if epoch:
-        version_str = f"{epoch}:{version_str}"
 
     purl = f"pkg:rpm/{namespace}/{name}@{version_str}?arch={arch}"
+    if epoch:
+        purl += f"&epoch={epoch}"
     return purl
 
 

--- a/python_scripts/sbom_utils.py
+++ b/python_scripts/sbom_utils.py
@@ -46,7 +46,7 @@ def get_rpm_purl(name, version, release, arch, *, epoch=None, namespace="fedora"
     version_str = f"{version}-{release}"
 
     purl = f"pkg:rpm/{namespace}/{name}@{version_str}?arch={arch}"
-    if epoch:
+    if epoch and str(epoch) != "0":
         purl += f"&epoch={epoch}"
     return purl
 

--- a/tests/test_merge_sboms.py
+++ b/tests/test_merge_sboms.py
@@ -651,7 +651,9 @@ class TestAttachBuildrootPackages(unittest.TestCase):
 
             # Check purl includes epoch
             purl = systemd_pkg['externalRefs'][0]['referenceLocator']
-            self.assertIn('2:252-13.el9', purl)
+            self.assertNotIn('2:252-13.el9', purl)
+            self.assertIn('252-13.el9', purl)
+            self.assertIn('epoch=2', purl)
         finally:
             os.unlink(lockfile_path)
             os.unlink(broot_arch_list_file)

--- a/tests/test_sbom_utils.py
+++ b/tests/test_sbom_utils.py
@@ -105,7 +105,7 @@ class TestGetRpmPurl(unittest.TestCase):
             arch="aarch64",
             epoch="2"
         )
-        self.assertEqual(purl, "pkg:rpm/fedora/systemd@2:252-13.el9?arch=aarch64")
+        self.assertEqual(purl, "pkg:rpm/fedora/systemd@252-13.el9?arch=aarch64&epoch=2")
 
     def test_rpm_purl_noarch(self):
         """Test RPM purl with noarch architecture."""


### PR DESCRIPTION
We were using epoch as part of version (epoch:version), while purl should have epoch as a separate attribute.